### PR TITLE
bugfix: health check isn't available sometimes

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -213,7 +213,7 @@ pub struct MarathonTask {
     pub startedAt: Option<String>,
     pub version: Option<String>,
     pub servicePorts: Option<Vec<u32>>,
-    pub healthCheckResults: Vec<HealthCheckResult>,
+    pub healthCheckResults: Option<Vec<HealthCheckResult>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
(E.G., while the application is mid-deployment)

If you query for tasks while an application is being deployed, rarathon will panic without this patch.
